### PR TITLE
File name changed from youtube-dl to yt-dlp

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,6 @@
 
 VRC_DIR="${HOME}/.local/share/Steam/steamapps/compatdata/438100/pfx/drive_c/users/steamuser/AppData/LocalLow/VRChat/VRChat"
 
-mv "${VRC_DIR}/Tools/youtube-dl.exe" "${VRC_DIR}/Tools/youtube-dl-orig.exe"
-cp ./youtube-dl.sh "${VRC_DIR}/Tools/youtube-dl.exe"
-chmod 555 "${VRC_DIR}/Tools/youtube-dl.exe"
+mv "${VRC_DIR}/Tools/yt-dlp.exe" "${VRC_DIR}/Tools/yt-dlp-orig.exe"
+cp ./youtube-dl.sh "${VRC_DIR}/Tools/yt-dlp.exe"
+chmod 555 "${VRC_DIR}/Tools/yt-dlp.exe"


### PR DESCRIPTION
VRChatがyoutube-dlからyt-dlpを使用するように変更されたため、`install.sh`の出力先ファイル名をyt-dlpに変更しました。